### PR TITLE
Added type check for compatibility with datetime.datetime

### DIFF
--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -230,8 +230,9 @@ def _datetime_to_com_time(dt_time):
 
         return dt_time
     else:
-        assert dt_time.microsecond == 0, "fractional seconds not yet handled"
-        return pywintypes.Time(dt_time.timetuple())
+		if type(dt_time) == 'datetime.datetime':
+			assert dt_time.microsecond == 0, "fractional seconds not yet handled"
+		return pywintypes.Time(dt_time.timetuple())
 
 
 def get_selection_address(xl_app):


### PR DESCRIPTION
Added type check so assert isn't triggered by a datetime.datetime without a microsecond property