### PR TITLE
added 'lastrowandcolumn'

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -69,6 +69,13 @@ def get_worksheet_name(xl_sheet):
     return xl_sheet.name.get()
 
 
+def get_worksheet_last_row_and_column(xl_sheet):
+    ur = xl_sheet.used_range
+    nrow = ur.first_row_index.get() + ur.count(each=kw.row) - 1
+    ncol = ur.first_column_index.get() + ur.count(each=kw.column) - 1
+    return nrow, ncol
+
+
 def get_xl_sheet(xl_workbook, sheet_name_or_index):
     return xl_workbook.sheets[sheet_name_or_index]
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -60,6 +60,10 @@ def get_worksheet_name(xl_sheet):
     return xl_sheet.Name
 
 
+def get_worksheet_last_row_and_column(xl_sheet):
+    return xl_sheet.Cells.SpecialCells(11).Row, xl_sheet.Cells.SpecialCells(11).Column
+
+
 def get_xl_sheet(xl_workbook, sheet_name_or_index):
     return xl_workbook.Sheets(sheet_name_or_index)
 

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -217,6 +217,11 @@ class Sheet(object):
         xlplatform.set_worksheet_name(self.xl_sheet, value)
 
     @property
+    def lastrowcol(self):
+        """Get or set the the last row and last column of the Sheet that is not empty."""
+        return xlplatform.get_worksheet_last_row_and_column(self.xl_sheet)
+
+    @property
     def index(self):
         """Returns the index of the Sheet."""
         return xlplatform.get_worksheet_index(self.xl_sheet)


### PR DESCRIPTION
Added a function lastrowcol in main.py to give the row number and column
number after which there is no more content on the worksheet, and the
corresponding implementation in win32com/windows and appscript/osx.
We discussed this a bit on stackoverflow. I started with working from
'xlLastCell' in Windows because that would prevent looking at rows or
columns with only deleted content, but I could not figure out how to do
that in appscript, so I used 'usedrange' there. I read somewhere that
usedrange also includes rows/columns with deleted content though when I
tried, that did not appear to be the case.