### PR TITLE
Headless/invisible window support

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -389,3 +389,7 @@ def save_workbook(xl_workbook, path):
 
 def open_template(fullpath):
     subprocess.call(['open', fullpath])
+
+def set_visible(xl_app, visible):
+    # FIXME: Implement
+    pass

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -85,7 +85,6 @@ def _get_latest_app():
     the application that appears first in the Running Object Table (ROT).
     """
     try:
-        _ = xl_workbook_current.Application.Visible
         return xl_workbook_current.Application
     except (NameError, pywintypes.com_error):
         return dynamic.Dispatch('Excel.Application')
@@ -94,7 +93,6 @@ def _get_latest_app():
 def open_workbook(fullname):
     xl_app = _get_latest_app()
     xl_workbook = xl_app.Workbooks.Open(fullname)
-    xl_app.Visible = True
     return xl_app, xl_workbook
 
 
@@ -104,7 +102,6 @@ def close_workbook(xl_workbook):
 
 def new_workbook():
     xl_app = _get_latest_app()
-    xl_app.Visible = True
     xl_workbook = xl_app.Workbooks.Add()
     return xl_app, xl_workbook
 
@@ -453,3 +450,6 @@ def save_workbook(xl_workbook, path):
 
 def open_template(fullpath):
     os.startfile(fullpath)
+
+def set_visible(xl_app, visible):
+    xl_app.visible = visible

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -39,8 +39,12 @@ class Workbook(object):
     To create a connection when the Python function is called from Excel, use:
 
     ``wb = Workbook.caller()``
+
+    The resulting Workbook will be visible by default. To open it without showing a window,
+    set visible to False. Or, to not change alter the visibility (e.g., if Excel is already running),
+    set visible to None.
     """
-    def __init__(self, fullname=None, xl_workbook=None):
+    def __init__(self, fullname=None, xl_workbook=None, visible=True):
         if xl_workbook:
             self.xl_workbook = xl_workbook
             self.xl_app = xlplatform.get_app(self.xl_workbook)
@@ -61,6 +65,9 @@ class Workbook(object):
 
         # Make the most recently created Workbook the default when creating Range objects directly
         xlplatform.set_xl_workbook_current(self.xl_workbook)
+
+        if visible is not None:
+            xlplatform.set_visible(self.xl_app, visible)
 
     @classmethod
     def caller(cls):
@@ -134,7 +141,7 @@ class Workbook(object):
         creating a new Workbook through ``Workbook()`` is acting on the same instance of Excel as this Workbook. Use
         like this: ``Workbook.current()``.
         """
-        return cls(xl_workbook=xlplatform.get_xl_workbook_current())
+        return cls(xl_workbook=xlplatform.get_xl_workbook_current(), visible=None)
 
     def set_current(self):
         """
@@ -933,13 +940,13 @@ class Range(object):
         .. versionadded:: 0.2.3
 
         Returns the address of the range in the specified format.
-        
+
         Arguments
         ---------
         row_absolute : bool, default True
             Set to True to return the row part of the reference as an absolute reference.
 
-        column_absolute : bool, default True   
+        column_absolute : bool, default True
             Set to True to return the column part of the reference as an absolute reference.
 
         include_sheetname : bool, default False
@@ -964,8 +971,8 @@ class Range(object):
             'Sheet1!A$1:C$3'
             >>> Range('Sheet1', (1,1), (3,3)).get_address(True, False, external=True)
             '[Workbook1]Sheet1!A$1:C$3'
-        """        
-        
+        """
+
         if include_sheetname and not external:
             # TODO: when the Workbook name contains spaces but not the Worksheet name, it will still be surrounded
             # by '' when include_sheetname=True. Also, should probably changed to regex
@@ -1007,7 +1014,7 @@ class Range(object):
         .. versionadded:: 0.3.0
 
         Adds a hyperlink to the specified Range (single Cell)
-        
+
         Arguments
         ---------
         address : str
@@ -1026,8 +1033,8 @@ class Range(object):
             screen_tip = address + ' - Click once to follow. Click and hold to select this cell.'
         xlplatform.set_hyperlink(self.xl_range, address, text_to_display, screen_tip)
 
-    @property                 
-    def color(self):      
+    @property
+    def color(self):
         """
         .. versionadded:: 0.3.0
 

--- a/xlwings/tests/test_xlwings.py
+++ b/xlwings/tests/test_xlwings.py
@@ -93,7 +93,7 @@ class TestWorkbook:
     def setUp(self):
         # Connect to test file and make Sheet1 the active sheet
         xl_file1 = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_workbook_1.xlsx')
-        self.wb = Workbook(xl_file1)
+        self.wb = Workbook(xl_file1, visible=False)
         Sheet('Sheet1').activate()
 
     def tearDown(self):
@@ -109,7 +109,7 @@ class TestWorkbook:
         assert_equal(self.wb.xl_workbook, Workbook.current().xl_workbook)
 
     def test_set_current(self):
-        wb2 = Workbook()
+        wb2 = Workbook(visible=False)
         assert_equal(Workbook.current().xl_workbook, wb2.xl_workbook)
         self.wb.set_current()
         assert_equal(Workbook.current().xl_workbook, self.wb.xl_workbook)
@@ -121,8 +121,8 @@ class TestWorkbook:
 
     def test_reference_two_unsaved_wb(self):
         """Covers GH Issue #63"""
-        wb1 = Workbook()
-        wb2 = Workbook()
+        wb1 = Workbook(visible=False)
+        wb2 = Workbook(visible=False)
 
         Range('A1').value = 2.  # wb2
         Range('A1', wkb=wb1).value = 1.  # wb1
@@ -136,7 +136,7 @@ class TestWorkbook:
     def test_save_naked(self):
 
         cwd = os.getcwd()
-        wb1 = Workbook()
+        wb1 = Workbook(visible=False)
         target_file_path = os.path.join(cwd, wb1.name + '.xlsx')
         if os.path.isfile(target_file_path):
             os.remove(target_file_path)
@@ -145,7 +145,7 @@ class TestWorkbook:
 
         assert_equal(os.path.isfile(target_file_path), True)
 
-        wb2 = Workbook(target_file_path)
+        wb2 = Workbook(target_file_path, visible=False)
         wb2.close()
 
         if os.path.isfile(target_file_path):
@@ -154,7 +154,7 @@ class TestWorkbook:
     def test_save_path(self):
 
         cwd = os.getcwd()
-        wb1 = Workbook()
+        wb1 = Workbook(visible=False)
         target_file_path = os.path.join(cwd, 'TestFile.xlsx')
         if os.path.isfile(target_file_path):
             os.remove(target_file_path)
@@ -163,7 +163,7 @@ class TestWorkbook:
 
         assert_equal(os.path.isfile(target_file_path), True)
 
-        wb2 = Workbook(target_file_path)
+        wb2 = Workbook(target_file_path, visible=False)
         wb2.close()
 
         if os.path.isfile(target_file_path):
@@ -174,7 +174,7 @@ class TestSheet:
     def setUp(self):
         # Connect to test file and make Sheet1 the active sheet
         xl_file1 = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_workbook_1.xlsx')
-        self.wb = Workbook(xl_file1)
+        self.wb = Workbook(xl_file1, visible=False)
         Sheet('Sheet1').activate()
 
     def tearDown(self):
@@ -259,7 +259,7 @@ class TestRange:
     def setUp(self):
         # Connect to test file and make Sheet1 the active sheet
         xl_file1 = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_range_1.xlsx')
-        self.wb = Workbook(xl_file1)
+        self.wb = Workbook(xl_file1, visible=False)
         Sheet('Sheet1').activate()
 
     def tearDown(self):
@@ -723,7 +723,7 @@ class TestChart:
     def setUp(self):
         # Connect to test file and make Sheet1 the active sheet
         xl_file1 = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_chart_1.xlsx')
-        self.wb = Workbook(xl_file1)
+        self.wb = Workbook(xl_file1, visible=False)
         Sheet('Sheet1').activate()
 
     def tearDown(self):


### PR DESCRIPTION
Adds the visible parameter to Workbook's `__init__`, defaulting to True to match the previous behavior. False makes the application invisible, and None does not alter its visibility.

Closes #149 

Please note that this is a bit of a hack, as it isn't a Workbook that's visible or not, it's the entire Excel app. However, because Workbook is currently the highest-level object, it was the most logical place to put this functionality.

OS X support needs to be implemented still, as I do not own a system to test it on.