### PR TITLE
setup.py: raise error when OS not supported.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ if sys.platform.startswith('win'):
 if sys.platform.startswith('darwin'):
     install_requires = ['psutil >= 2.0.0', 'appscript >= 1.0.1']
     data_files =[]
+else:
+    raise OSError("currently only Windows and OSX are supported.")
 
 setup(
     name='xlwings',


### PR DESCRIPTION
This tiny modification should make it easier for linux users to figure out why the installation fails.

```
Processing /Users/ch/repo/xlwings
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/var/folders/x7/gzk1nby55r39gjz5y4gbl3lr0000gn/T/pip-CpB0u6-build/setup.py", line 23, in <module>
        raise OSError("currently only Windows and OSX are supported.")
    OSError: currently only Windows and OSX are supported.
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

      File "<string>", line 20, in <module>

      File "/var/folders/x7/gzk1nby55r39gjz5y4gbl3lr0000gn/T/pip-CpB0u6-build/setup.py", line 23, in <module>

        raise OSError("currently only Windows and OSX are supported.")


 15 if sys.platform.startswith('win'):

    OSError: currently only Windows and OSX are supported.

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /var/folders/x7/gzk1nby55r39gjz5y4gbl3lr0000gn/T/pip-CpB0u6-build
```
