### PR TITLE
Replaced GetObject/GetActiveObject/RunningObjectTable approach with HWND

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(os.path.dirname(__file__), 'xlwings', '__init__.py')) as 
 
 # Dependencies
 if sys.platform.startswith('win'):
-    install_requires = []  # pywin32 can't be installed (yet) with pip
+    install_requires = ['comtypes']  # pywin32 can't be installed (yet) with pip
     # This places dlls next to python.exe for standard setup and in the parent folder for virtualenv
     data_files = [('', ['xlwings32.dll', 'xlwings64.dll'])]
 elif sys.platform.startswith('darwin'):

--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -78,7 +78,7 @@ def is_excel_running():
     return False
 
 
-def get_workbook(fullname, app_target=None):
+def get_open_workbook(fullname, app_target=None):
     """
     Get the appscript Workbook object.
     On Mac, it seems that we don't have to deal with >1 instances of Excel,
@@ -412,14 +412,6 @@ def get_color(xl_range):
         return None
     else:
         return tuple(xl_range.interior_object.color.get())
-
-
-def get_xl_workbook_from_xl(fullname, app_target=None):
-    """
-    Doesn't really do anything on Mac, but on Windows, this is needed due to some
-    Workbooks not turning up in the RunningObjectTable
-    """
-    return get_workbook(fullname, app_target)[1]
 
 
 def save_workbook(xl_workbook, path):

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -462,6 +462,9 @@ def autofit_sheet(sheet, axis):
         sheet.xl_sheet.Columns.AutoFit()
 
 
+xl_workboook_current = None
+
+
 def set_xl_workbook_current(xl_workbook):
     global xl_workbook_current
     xl_workbook_current = xl_workbook

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -138,7 +138,7 @@ def get_open_workbook(fullname, app_target=None, hwnd=None):
                     if (xl_workbook.FullName.lower() not in duplicate_fullnames) or (hwnd is not None):
                         return xl_app, xl_workbook
                     else:
-                        warn('This Workbook is opened in multiple instances.'
+                        warn('This Workbook is open in multiple instances.'
                              'The connection was made with the one that was last active.')
                         return xl_app, xl_workbook
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -135,7 +135,7 @@ def get_open_workbook(fullname, app_target=None, hwnd=None):
     for xl_app in xl_apps:
         for xl_workbook in get_all_open_xl_workbooks(xl_app):
             if xl_workbook.FullName.lower() == fullname.lower():
-                    if xl_workbook.FullName.lower() not in duplicate_fullnames:
+                    if (xl_workbook.FullName.lower() not in duplicate_fullnames) or (hwnd is not None):
                         return xl_app, xl_workbook
                     else:
                         warn('This Workbook is opened in multiple instances.'

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -15,8 +15,7 @@ os.chdir(cwd)
 from warnings import warn
 import pywintypes
 import pythoncom
-import win32pdh
-from win32com.client import GetObject, GetActiveObject, dynamic, Dispatch
+from win32com.client import dynamic, Dispatch
 import win32timezone
 import win32gui
 import datetime as dt

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -82,8 +82,13 @@ def get_xl_apps():
     xl_apps = []
     hwnds = get_excel_hwnds()
     for hwnd in hwnds:
-        xl_app = get_xl_app_from_hwnd(hwnd)
-        xl_apps.append(xl_app)
+        try:
+            xl_app = get_xl_app_from_hwnd(hwnd)
+            xl_apps.append(xl_app)
+        except WindowsError:
+            # This happens if the bare Excel Application is open without Workbook
+            # i.e. there is no 'EXCEL7' child hwnd that would be necessary to make a connection
+            pass
     return xl_apps
 
 

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -141,12 +141,9 @@ class Workbook(object):
             self.xl_app = xlplatform.get_app(self.xl_workbook, app_target)
         elif fullname:
             self.fullname = fullname
-            if not os.path.isfile(fullname):
-                # unsaved Workobook, e.g. 'Workbook1'
-                self.xl_app, self.xl_workbook = xlplatform.get_workbook(self.fullname, app_target)
-            elif xlplatform.is_file_open(self.fullname):
-                # Connect to an open Workbook
-                self.xl_app, self.xl_workbook = xlplatform.get_workbook(self.fullname, app_target)
+            if not os.path.isfile(fullname) or xlplatform.is_file_open(self.fullname):
+                # Connect to unsaved Workbook (e.g. 'Workbook1') or to an opened Workbook
+                self.xl_app, self.xl_workbook = xlplatform.get_open_workbook(self.fullname, app_target)
             else:
                 # Open Excel and the Workbook
                 self.xl_app, self.xl_workbook = xlplatform.open_workbook(self.fullname, app_target)
@@ -187,16 +184,16 @@ class Workbook(object):
         """
         if hasattr(Workbook, '_mock_file'):
             # Use mocking Workbook, see Workbook.set_mock_caller()
-            _, xl_workbook = xlplatform.get_workbook(Workbook._mock_file)
+            _, xl_workbook = xlplatform.get_open_workbook(Workbook._mock_file)
             return cls(xl_workbook=xl_workbook)
         elif len(sys.argv) > 2 and sys.argv[2] == 'from_xl':
             # Connect to the workbook from which this code has been invoked
             fullname = sys.argv[1].lower()
             if sys.platform.startswith('win'):
-                xl_workbook = xlplatform.get_xl_workbook_from_xl(fullname, app_target=sys.argv[3], hwnd=sys.argv[4])
+                xl_app, xl_workbook = xlplatform.get_open_workbook(fullname, hwnd=sys.argv[4])
                 return cls(xl_workbook=xl_workbook)
             else:
-                xl_workbook = xlplatform.get_xl_workbook_from_xl(fullname, app_target=sys.argv[3])
+                xl_app, xl_workbook = xlplatform.get_open_workbook(fullname, app_target=sys.argv[3])
                 return cls(xl_workbook=xl_workbook, app_target=sys.argv[3])
         elif xlplatform.get_xl_workbook_current():
             # Called through ExcelPython connection

--- a/xlwings/tests/test_xlwings.py
+++ b/xlwings/tests/test_xlwings.py
@@ -7,7 +7,7 @@ import os
 import sys
 import shutil
 import nose
-from nose.tools import assert_equal, raises, assert_greater
+from nose.tools import assert_equal, raises, assert_true
 from datetime import datetime, date
 from xlwings import Application, Workbook, Sheet, Range, Chart, ChartType, RgbColor, Calculation
 
@@ -686,7 +686,7 @@ class TestRange:
         result_before = Range('Sheet1', 'A1').width
         Range('Sheet1', 'A1:D4').column_width = 12.0
         result_after = Range('Sheet1', 'A1').width
-        assert_greater(result_after, result_before)
+        assert_true(result_after > result_before)
 
     def test_height(self):
         Range('Sheet1', 'A1:D4').row_height = 60.0

--- a/xlwings/tests/test_xlwings.py
+++ b/xlwings/tests/test_xlwings.py
@@ -234,7 +234,7 @@ class TestWorkbook:
         wb.close()
         shutil.move(dst, src)
 
-    def unsaved_workbook_reference(self):
+    def test_unsaved_workbook_reference(self):
         wb = Workbook(app_visible=False, app_target=APP_TARGET)
         Range('B2').value = 123
         wb2 = Workbook(wb.name, app_visible=False, app_target=APP_TARGET)

--- a/xlwings/tests/test_xlwings.py
+++ b/xlwings/tests/test_xlwings.py
@@ -102,6 +102,12 @@ def _skip_if_not_default_xl():
         raise nose.SkipTest('not Excel default')
 
 
+def class_teardown(wb):
+    wb.close()
+    if sys.platform.startswith('win'):
+        Application(wb).quit()
+
+
 class TestApplication:
     def setUp(self):
         # Connect to test file and make Sheet1 the active sheet
@@ -110,8 +116,7 @@ class TestApplication:
         Sheet('Sheet1').activate()
 
     def tearDown(self):
-        self.wb.close()
-        Application(self.wb).quit()
+        class_teardown(self.wb)
 
     def test_screen_updating(self):
         Application(wkb=self.wb).screen_updating = False
@@ -146,8 +151,7 @@ class TestWorkbook:
         Sheet('Sheet1').activate()
 
     def tearDown(self):
-        self.wb.close()
-        Application(self.wb).quit()
+        class_teardown(self.wb)
 
     def test_name(self):
         assert_equal(self.wb.name, 'test_workbook_1.xlsx')
@@ -243,6 +247,7 @@ class TestWorkbook:
         Range('B2').value = 123
         wb2 = Workbook(wb.name, app_visible=False, app_target=APP_TARGET)
         assert_equal(Range('B2', wkb=wb2).value, 123)
+        wb2.close()
 
 
 class TestSheet:
@@ -253,8 +258,7 @@ class TestSheet:
         Sheet('Sheet1').activate()
 
     def tearDown(self):
-        self.wb.close()
-        Application(self.wb).quit()
+        class_teardown(self.wb)
 
     def test_activate(self):
         Sheet('Sheet2').activate()
@@ -341,8 +345,7 @@ class TestRange:
         Sheet('Sheet1').activate()
 
     def tearDown(self):
-        self.wb.close()
-        Application(self.wb).quit()
+        class_teardown(self.wb)
 
     def test_cell(self):
         params = [('A1', 22),
@@ -860,15 +863,11 @@ class TestRange:
         assert_equal(Range('B3:F5').last_cell.column, 6)
 
     def test_get_set_named_range(self):
-        wb = Workbook(app_visible=False)
-        Range('A1').name = 'test1'
-        assert_equal(Range('A1').name, 'test1')
+        Range('A100').name = 'test1'
+        assert_equal(Range('A100').name, 'test1')
 
-        Range('A2:B4').name = 'test2'
-        assert_equal(Range('A2:B4').name, 'test2')
-
-        wb.close()
-
+        Range('A200:B204').name = 'test2'
+        assert_equal(Range('A200:B204').name, 'test2')
 
 class TestChart:
     def setUp(self):
@@ -878,8 +877,7 @@ class TestChart:
         Sheet('Sheet1').activate()
 
     def tearDown(self):
-        self.wb.close()
-        Application(self.wb).quit()
+        class_teardown(self.wb)
 
     def test_add_keywords(self):
         name = 'My Chart'

--- a/xlwings/tests/test_xlwings.py
+++ b/xlwings/tests/test_xlwings.py
@@ -96,6 +96,7 @@ def _skip_if_no_pandas():
     if pd is None:
         raise nose.SkipTest('pandas missing')
 
+
 def _skip_if_not_default_xl():
     if APP_TARGET is not None:
         raise nose.SkipTest('not Excel default')
@@ -110,6 +111,7 @@ class TestApplication:
 
     def tearDown(self):
         self.wb.close()
+        Application(self.wb).quit()
 
     def test_screen_updating(self):
         Application(wkb=self.wb).screen_updating = False
@@ -145,6 +147,7 @@ class TestWorkbook:
 
     def tearDown(self):
         self.wb.close()
+        Application(self.wb).quit()
 
     def test_name(self):
         assert_equal(self.wb.name, 'test_workbook_1.xlsx')
@@ -217,6 +220,7 @@ class TestWorkbook:
             os.remove(target_file_path)
 
     def test_mock_caller(self):
+        # Can't really run this one with app_visible=False
         _skip_if_not_default_xl()
 
         Workbook.set_mock_caller(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_workbook_1.xlsx'))
@@ -229,7 +233,7 @@ class TestWorkbook:
         src = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'unicode_path.xlsx')
         dst = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ünicödé_päth.xlsx')
         shutil.move(src, dst)
-        wb = Workbook(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ünicödé_päth.xlsx'), app_target=APP_TARGET)
+        wb = Workbook(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ünicödé_päth.xlsx'), app_visible=False, app_target=APP_TARGET)
         Range('A1').value = 1
         wb.close()
         shutil.move(dst, src)
@@ -250,6 +254,7 @@ class TestSheet:
 
     def tearDown(self):
         self.wb.close()
+        Application(self.wb).quit()
 
     def test_activate(self):
         Sheet('Sheet2').activate()
@@ -337,6 +342,7 @@ class TestRange:
 
     def tearDown(self):
         self.wb.close()
+        Application(self.wb).quit()
 
     def test_cell(self):
         params = [('A1', 22),
@@ -854,7 +860,7 @@ class TestRange:
         assert_equal(Range('B3:F5').last_cell.column, 6)
 
     def test_get_set_named_range(self):
-        wb = Workbook()
+        wb = Workbook(app_visible=False)
         Range('A1').name = 'test1'
         assert_equal(Range('A1').name, 'test1')
 
@@ -873,6 +879,7 @@ class TestChart:
 
     def tearDown(self):
         self.wb.close()
+        Application(self.wb).quit()
 
     def test_add_keywords(self):
         name = 'My Chart'

--- a/xlwings/utils.py
+++ b/xlwings/utils.py
@@ -13,3 +13,9 @@ def int_to_rgb(number):
 def rgb_to_int(rgb):
     """Given an rgb, return an int"""
     return rgb[0] + (rgb[1] * 256) + (rgb[2] * 256 * 256)
+
+
+def get_duplicates(seq):
+    seen = set()
+    duplicates = set(x for x in seq if x in seen or seen.add(x))
+    return duplicates


### PR DESCRIPTION
This finally allows us to work reliably across different instances and correctly recognizes if a file is open even if it is from an untrusted location that would not be registered in the ROT.