### PR TITLE
Add left and top properties for Range

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -356,6 +356,14 @@ def get_height(xl_range):
     return xl_range.height.get()
 
 
+def get_left(xl_range):
+    return xl_range.left.get()
+
+
+def get_top(xl_range):
+    return xl_range.left.get()
+
+
 def autofit(range_, axis):
     address = range_.xl_range.get_address()
     _xl_app.screen_updating.set(False)

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -463,8 +463,16 @@ def get_width(xl_range):
 
 def get_height(xl_range):
     return xl_range.Height
+	
+
+def get_left(xl_range):
+    return xl_range.Left
 
 
+def get_top(xl_range):
+    return xl_range.Top
+
+	
 def autofit(range_, axis):
     if axis == 'rows' or axis == 'r':
         range_.xl_range.Rows.AutoFit()

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -1153,7 +1153,31 @@ class Range(object):
         .. versionadded:: 0.4.0
         """
         return xlplatform.get_height(self.xl_range)
+		
+    @property
+    def left(self):
+        """
+        .. versionadded:: 0.6.0
+        Returns the distance, in points, from the left edge of column A to the left edge of the range. Read-only.
 
+        Returns
+        -------
+        float
+        """
+        return xlplatform.get_left(self.xl_range)
+
+    @property
+    def top(self):
+        """
+        .. versionadded:: 0.6.0
+        Returns the distance, in points, from the top edge of row 1 to the top edge of the range. Read-only.
+
+        Returns
+        -------
+        float
+        """
+        return xlplatform.get_top(self.xl_range)
+		
     def autofit(self, axis=None):
         """
         Autofits the width of either columns, rows or both.

--- a/xlwings/tests/test_xlwings.py
+++ b/xlwings/tests/test_xlwings.py
@@ -778,6 +778,16 @@ class TestRange:
         result = Range('Sheet1', 'A1:D4').height
         assert_equal(240.0, result)
 
+    def test_left(self):
+        assert_equal(Range('Sheet1','A1').left, 0.0)
+        Range('Sheet1','A1').column_width = 20.0
+        assert_equal(Range('Sheet1','B1').left, Range('Sheet1','A1').width)
+
+    def test_top(self):
+        assert_equal(Range('Sheet1','A1').top, 0.0)
+        Range('Sheet1','A1').row_height = 20.0
+        assert_equal(Range('Sheet1','A2').top, Range('Sheet1','A1').height)
+
     def test_autofit_range(self):
         # TODO: compare col/row widths before/after - not implemented yet
         Range('Sheet1', 'A1:D4').value = 'test_string'


### PR DESCRIPTION
Add left and top properties for Range, which return their locations on the worksheet in points. 

Should make this easier:
http://stackoverflow.com/questions/33725112/how-to-place-a-chart-with-xlwings-at-a-particular-worksheet-range-address-from-p