### PR TITLE
Named range fails if referenced sheet is not the active sheet

### DIFF
--- a/xlwings/tests/test_range.py
+++ b/xlwings/tests/test_range.py
@@ -1,0 +1,42 @@
+import unittest
+
+from win32com.client.dynamic import Dispatch
+from xlwings import Range, Workbook
+
+
+class TestDemonstrateRangeBug(unittest.TestCase):
+    """ This test case demonstrates a bug where a Range cannot be created with
+    a named range referring to a sheet other than the active sheet.
+    """
+    def setUp(self):
+        self.excel_application = Dispatch('Excel.Application')
+        self.excel_application.Visible = False
+        self.excel_application.DisplayAlerts = False
+        self.workbook = self.excel_application.WorkBooks.Add()
+
+        # use win32com method to add a name referring to a cell on sheet2
+        self.sheet1 = self.excel_application.ActiveSheet
+        self.sheet2 = self.workbook.Sheets.Add()
+        cell_ref = "$A$1"
+        ext_ref_str = "={}!{}".format(self.sheet2.Name, cell_ref)
+        self.ext_named_range = "external_reference"
+        self.workbook.Names.Add(Name=self.ext_named_range,
+                                RefersTo=ext_ref_str)
+
+        # convert the COM workbook to an xlwings.Workbook
+        self.work_book = Workbook(xl_workbook=self.workbook)
+
+    def test_create_range_on_sheet_referenced(self):
+        self.sheet2.Activate()
+        range_from_sheet_2 = Range(self.ext_named_range)
+        self.assertIsNone(range_from_sheet_2.value)
+
+    def test_create_range_on_different_sheet(self):
+        """This test demonstrates the bug.
+        """
+        self.sheet1.Activate()
+        range_from_sheet_1 = Range(self.ext_named_range)
+        self.assertIsNone(range_from_sheet_1.value)
+
+    def tearDown(self):
+        self.excel_application.Quit()


### PR DESCRIPTION
This PR contributes a failing test demonstrating a bug I have come across in with the `Range` class.

Suppose your workbook has a named range `'my_ref'` that includes a sheet name, like `=Sheet1!$A$1`.
If you create a `Range` using `'my_ref'`, then it will be successful if `Sheet1` is active and will fail with a `com_error` if any other sheet is active.  There appears to be a built-in assumption that a named range refers to a cell on the active sheet.
This bug is demonstrated by the test case this PR adds.  One test method passes when the `Range` is created on same sheet pointed to by the reference.  The other test method fails when a different sheet is activated before the `Range` is instantiated.

```
(.devenv)C:\Users\IEUser\Documents\GitHub\xlwings>nosetests xlwings\tests\test_range.py -v
This test demonstrates the bug. ... ERROR
test_create_range_on_sheet_referenced (xlwings.tests.test_range.TestDemonstrateRangeBug) ... ok

======================================================================
ERROR: This test demonstrates the bug.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\IEUser\Documents\GitHub\xlwings\xlwings\tests\test_range.py", line 38, in test_create_range_on_different_sheet
    range_from_sheet_1 = Range(self.ext_named_range)
  File "C:\Users\IEUser\Documents\GitHub\xlwings\xlwings\main.py", line 707, in __init__
    self.row1 = xlplatform.get_first_row(self.xl_sheet, range_address)
  File "C:\Users\IEUser\Documents\GitHub\xlwings\xlwings\_xlwindows.py", line 244, in get_first_row
    return xl_sheet.Range(range_address).Row
  File "C:\Users\IEUser\Documents\GitHub\slb-poet\.devenv\lib\site-packages\win32com\gen_py\00020813-0000-0000-C000-000000000046x0x1x9\_Worksheet.py", line 239, in Range
    , Cell2)
com_error: (-2147352567, 'Exception occurred.', (0, None, None, None, 0, -2146827284), None)
-------------------- >> begin captured logging << --------------------
comtypes: DEBUG: CoInitializeEx(None, 2)
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 2 tests in 1.414s

FAILED (errors=1)
```