### PR TITLE
Expand environmental vars

### DIFF
--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -91,7 +91,8 @@ def xlarg(arg, marshal=None, ndim=None, **kwargs):
 
 udf_scripts = {}
 def udf_script(filename):
-    filename = filename.lower()
+    filename = os.path.expandvars(filename)
+    filename = os.path.normcase(filename)
     mtime = os.path.getmtime(filename)
     if filename in udf_scripts:
         mtime2, vars = udf_scripts[filename]

--- a/xlwings/xlwings.bas
+++ b/xlwings/xlwings.bas
@@ -239,7 +239,7 @@ Sub ExecuteWindows(IsFrozen As Boolean, PythonCommand As String, PYTHON_WIN As S
     WORKBOOK_FULLNAME = ThisWorkbook.FullName
 
     If IsFrozen = False Then
-        RunCommand = "python -c ""import sys; sys.path.extend(r'" & PYTHONPATH & "'.split(';')); " & PythonCommand & """ "
+        RunCommand = "python -c ""import sys,os;sys.path.extend(os.path.normcase(os.path.expandvars(r'" & PYTHONPATH & "')).split(';')); " & PythonCommand & """ "
     ElseIf IsFrozen = True Then
         RunCommand = PythonCommand & " "
     End If
@@ -458,7 +458,7 @@ Function XLPyCommand()
     Dim SHOW_LOG As Boolean, OPTIMIZED_CONNECTION As Boolean
 
     Res = Settings(PYTHON_WIN, PYTHON_MAC, PYTHON_FROZEN, PYTHONPATH, UDF_PATH, LOG_FILE, SHOW_LOG, OPTIMIZED_CONNECTION)
-    Tail = " -c ""import sys;sys.path.extend(r'" & PYTHONPATH & "'.split(';'));import xlwings.server; xlwings.server.serve('$(CLSID)')"""
+    Tail = " -c ""import sys,os;sys.path.extend(os.path.normcase(os.path.expandvars(r'" & PYTHONPATH & "')).split(';'));import xlwings.server; xlwings.server.serve('$(CLSID)')"""
     If PYTHON_WIN = "" Then
         XLPyCommand = "pythonw.exe" + Tail
     ElseIf LCase$(Right$(PYTHON_WIN, 4)) = ".exe" Then

--- a/xlwings/xlwings.bas
+++ b/xlwings/xlwings.bas
@@ -291,9 +291,13 @@ Function ReadFile(ByVal FileName As String)
     Dim Content As String
     Dim Token As String
     Dim FileNum As Integer
+    Dim Shell as Object
 
     #If Mac Then
         FileName = ToMacPath(FileName)
+    #Else
+        Set objShell = CreateObject("WScript.Shell")
+        FileName = objShell.ExpandEnvironmentStrings(FileName)
     #End If
 
     FileNum = FreeFile

--- a/xlwings/xlwings.bas
+++ b/xlwings/xlwings.bas
@@ -291,7 +291,7 @@ Function ReadFile(ByVal FileName As String)
     Dim Content As String
     Dim Token As String
     Dim FileNum As Integer
-    Dim Shell as Object
+    Dim objShell as Object
 
     #If Mac Then
         FileName = ToMacPath(FileName)


### PR DESCRIPTION
Expand the variables in the xlwings.bas config paths.
Use python for PYTHONPATH and UDF_PATH, use the windows shell for the logfile on windows.

This also fixes the slashes in some paths as well, with seeming no bad effects.

Has only been tested on windows and python 2.7.11