### PR TITLE
Return shortened exception in ud fs

### DIFF
--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -117,7 +117,7 @@ def call_udf(script_name, func_name, args, this_workbook):
     return conversion.write(ret, None, ret_info)
 
 
-def generate_vba_wrapper(script_vars, f):
+def generate_vba_wrapper(script_vars, f, short_errors):
 
     vba = VBAWriter(f)
 
@@ -194,18 +194,21 @@ def generate_vba_wrapper(script_vars, f):
                 if ftype == "Function":
                     vba.write("Exit " + ftype + "\n")
                     vba.write_label("failed")
-                    vba.write(fname + " = Err.Description\n")
+                    if short_errors:
+                        vba.write(fname + ' = Split(Err.Description, vbLf)(0)\n')
+                    else:
+                        vba.write(fname + ' = Err.Description\n')
 
             vba.write('End ' + ftype + "\n")
             vba.write("\n")
 
 
-def import_udfs(script_path, xl_workbook):
+def import_udfs(script_path, xl_workbook, short_errors):
 
     script_vars = udf_script(script_path)
 
     tf = tempfile.NamedTemporaryFile(mode='w', delete=False)
-    generate_vba_wrapper(script_vars, tf.file)
+    generate_vba_wrapper(script_vars, tf.file, short_errors)
     tf.close()
 
     try:

--- a/xlwings/xlwings.bas
+++ b/xlwings/xlwings.bas
@@ -516,6 +516,11 @@ End Sub
 
 Sub ImportPythonUDFs()
     Dim scriptPath As String, tempPath As String
+    
+    ' set this constant to False to get full stacktrace in case of exception
+    ' set this constant to True to get only exception raised
+    Const SHORT_ERRORS As Boolean = True
+    
     scriptPath = PyScriptPath()
-    tempPath = Py.Str(Py.Call(Py.Module("xlwings"), "import_udfs", Py.Tuple(scriptPath, ThisWorkbook)))
+    tempPath = Py.Str(Py.Call(Py.Module("xlwings"), "import_udfs", Py.Tuple(scriptPath, ThisWorkbook, SHORT_ERRORS)))
 End Sub


### PR DESCRIPTION
Felix, here is the PR to simplify the returned value for UDFs in case of exception (do not return the full stacktrace). It is still possible to get full stack trace by changing a constant in the ImportPythonUDFs.

PS: I haven't changed doc/.xlam/other files that may need to be changed too