### PR TITLE
Develop

### DIFF
--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -1,7 +1,5 @@
 import os
 import sys
-import itertools
-
 
 # Hack to find pythoncom.dll - needed for some distribution/setups (includes seemingly unused import win32api)
 # E.g. if python is started with the full path outside of the python path, then it almost certainly fails
@@ -42,7 +40,6 @@ from . import PY3
 time_types = (dt.date, dt.datetime, type(pywintypes.Time(0)))
 if np:
     time_types = time_types + (np.datetime64,)
-
 
 # Constants
 OBJID_NATIVEOM = -16
@@ -152,9 +149,9 @@ def get_open_workbook(fullname, app_target=None, hwnd=None):
     for xl_app in xl_apps:
         for xl_workbook in get_all_open_xl_workbooks(xl_app):
             if (
-                xl_workbook.FullName.lower() == fullname.lower() or
-                xl_workbook.Name.lower() == fullname.lower()
-               ):
+                            xl_workbook.FullName.lower() == fullname.lower() or
+                            xl_workbook.Name.lower() == fullname.lower()
+            ):
                 if (xl_workbook.FullName.lower() not in duplicate_fullnames) or (hwnd is not None):
                     return xl_app, xl_workbook
                 else:
@@ -287,9 +284,9 @@ def get_range_from_indices(xl_sheet, first_row, first_column, last_row, last_col
                           xl_sheet.Cells(last_row, last_column))
 
 
-
 # empirical limit of # cells that can be read in one shot
 LIMIT_CELLS = 4000000
+
 
 def get_value_from_range(xl_range):
     if xl_range.Count > LIMIT_CELLS:
@@ -298,14 +295,16 @@ def get_value_from_range(xl_range):
 
         sh = xl_range.Parent
 
-        nrow,ncolumn = xl_range.Rows.Count, xl_range.Columns.Count
+        nrow, ncolumn = xl_range.Rows.Count, xl_range.Columns.Count
         batch_rows = int(LIMIT_CELLS / ncolumn)
 
         steps = range(0, nrow, batch_rows) + [nrow]
-        def read_batch(s,e):
-            return sh.Range(sh.Cells(s+1,1),sh.Cells(e,ncolumn)).Value
 
-        return list(itertools.chain.from_iterable(read_batch(s,e) for s,e in zip(steps[:-1],steps[1:])))
+        v = []
+        for s, e in zip(steps[:-1], steps[1:]):
+            v.extend(sh.Range(sh.Cells(s + 1, 1), sh.Cells(e, ncolumn)).Value)
+
+        return v
     else:
         v = xl_range.Value
         if isinstance(v, tuple):
@@ -326,9 +325,9 @@ def clean_value_data(data, datetime_builder, empty_as, number_builder):
                 if c is None else
                 c
                 for c in row
-            ]
+                ]
             for row in data
-        ]
+            ]
     else:
         return [
             [
@@ -338,9 +337,9 @@ def clean_value_data(data, datetime_builder, empty_as, number_builder):
                 if c is None
                 else c
                 for c in row
-            ]
+                ]
             for row in data
-        ]
+            ]
 
 
 def get_value_from_index(xl_sheet, row_index, column_index):
@@ -373,12 +372,12 @@ def _com_time_to_datetime(com_time, datetime_builder):
         # We copy to a new datetime so that the returned type is the same between 2/3
         # Changed: We make the datetime object timezone naive as Excel doesn't provide info
         return datetime_builder(month=com_time.month, day=com_time.day, year=com_time.year,
-                           hour=com_time.hour, minute=com_time.minute, second=com_time.second,
-                           microsecond=com_time.microsecond, tzinfo=None)
+                                hour=com_time.hour, minute=com_time.minute, second=com_time.second,
+                                microsecond=com_time.microsecond, tzinfo=None)
     else:
         assert com_time.msec == 0, "fractional seconds not yet handled"
         return datetime_builder(month=com_time.month, day=com_time.day, year=com_time.year,
-                           hour=com_time.hour, minute=com_time.minute, second=com_time.second)
+                                hour=com_time.hour, minute=com_time.minute, second=com_time.second)
 
 
 def _datetime_to_com_time(dt_time):
@@ -531,7 +530,7 @@ def get_width(xl_range):
 
 def get_height(xl_range):
     return xl_range.Height
-	
+
 
 def get_left(xl_range):
     return xl_range.Left
@@ -540,7 +539,7 @@ def get_left(xl_range):
 def get_top(xl_range):
     return xl_range.Top
 
-	
+
 def autofit(range_, axis):
     if axis == 'rows' or axis == 'r':
         range_.xl_range.Rows.AutoFit()
@@ -598,7 +597,7 @@ def add_sheet(xl_workbook, before, after):
         new_sheet_index = after.xl_sheet.Index + 1
         if new_sheet_index > count:
             xl_sheet = xl_workbook.Worksheets.Add(Before=xl_workbook.Sheets(after.xl_sheet.Index))
-            xl_workbook.Worksheets(xl_workbook.Worksheets.Count)\
+            xl_workbook.Worksheets(xl_workbook.Worksheets.Count) \
                 .Move(Before=xl_workbook.Sheets(xl_workbook.Worksheets.Count - 1))
             xl_workbook.Worksheets(xl_workbook.Worksheets.Count).Activate()
         else:


### PR DESCRIPTION
if the range is above  4Mio elements, the range.Value raises an exception 'Not enough storage is available to complete this operation.'
To go beyond 4mio, we read the data in batches of max 4mio and aggregate the results.

We return lists when range has more than one cell (instead of tuples) as pandas.DataFrame need lists (and not tuples) in their data arg of constructor (useful if we want to be able to skip any "cleaning data" step afterwards in the pipe)