### PR TITLE
Distinguish VBA macro vs macro

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -705,7 +705,7 @@ def delete_sheet(sheet):
     _xl_app.display_alerts.set(True)
 
 
-def run(wb, command, app_, args):
+def run(command, app_, args):
     # kwargs = {'arg{0}'.format(i): n for i, n in enumerate(args, 1)}  # only for > PY 2.6
     kwargs = dict(('arg{0}'.format(i), n) for i, n in enumerate(args, 1))
-    return app_.xl_app.run_VB_macro("'{0}'!{1}".format(wb.name, command), **kwargs)
+    return app_.xl_app.run_VB_macro(command, **kwargs)

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -807,5 +807,5 @@ def delete_sheet(sheet):
     sheet.xl_workbook.Application.DisplayAlerts = alerts_state
 
 
-def run(wb, command, app_, args):
-    return app_.xl_app.Run("'{0}'!{1}".format(wb.name, command), *args)
+def run(command, app_, args):
+    return app_.xl_app.Run(command, *args)


### PR DESCRIPTION
Here we propose an alternative to fix #483 by @skasi7. Basically we're modifying the internals of xlwings so it does not prepend the name of the workbook to the function call so we can use functions outside it. This was only tested on Windows and not in OS X.

What do you think of this? We are open for other suggestions and ideas and eventually we would like to converge with the upstream project, so please tell us your feelings about this change.