### PR TITLE
Modification of the converter class so it is possible to overload the ToValueStage and FromValueStage

### DIFF
--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -137,5 +137,5 @@ class Converter(Accessor):
     def writer(cls, options):
         return (
             cls.base_writer(options)
-            .prepend_stage(Converter.ToValueStage(cls.write_value, options))
+            .prepend_stage(cls.ToValueStage(cls.write_value, options))
         )

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -130,7 +130,7 @@ class Converter(Accessor):
     def reader(cls, options):
         return (
             cls.base_reader(options)
-            .append_stage(Converter.FromValueStage(cls.read_value, options))
+            .append_stage(cls.FromValueStage(cls.read_value, options))
         )
 
     @classmethod


### PR DESCRIPTION
I needed to access the ConversionContext in a converter of mine.
I may be wrong but it seems the current architecture only gives the ConversionContext.value to the converter.

I chose to overload the ToValueStage class in my converter this way : 

```
    class ToValueStage(object):
        def __init__(self, write_value, options):
            self.write_value = write_value
            self.options = options

        def __call__(self, c):
            self.options['range'] = c.range
            c.value = self.write_value(c.value, self.options)
```

and consequently I had to change slighty the Converter class to make it work.
