### PR TITLE
Display exception message parameters

### DIFF
--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -333,7 +333,7 @@ def serve(clsid="{506e67c3-55b5-48c3-a035-eed5deea7d6d}"):
                 task()
             except:
                 import traceback
-                print("TaskQueue '%s' threw an exeception: %s", task, traceback.format_exc())
+                print("TaskQueue '%s' threw an exception: %s" % task, traceback.format_exc())
 
     pythoncom.CoRevokeClassObject(revokeId)
     pythoncom.CoUninitialize()


### PR DESCRIPTION
Syntax was not the right one, leading to parameters not being displayed as replacement of %s occurrences.
"exception" was written "exeception"