### PR TITLE
Retry COM call in case retry error is returned

### DIFF
--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -329,12 +329,29 @@ def serve(clsid="{506e67c3-55b5-48c3-a035-eed5deea7d6d}"):
                 break
 
             task = idle_queue.pop(0)
-            try:
-                task()
-            except:
-                import traceback
-                print("TaskQueue '%s' threw an exception: %s" % task, traceback.format_exc())
+            _execute_task(task)
 
     pythoncom.CoRevokeClassObject(revokeId)
     pythoncom.CoUninitialize()
 
+
+def _execute_task(task):
+    try:
+        task()
+    except Exception as e:
+        if _ask_for_retry(e) and _can_retry(task):
+            print("Retrying TaskQueue '%s'." % task)
+            _execute_task(task)
+        else:
+            import traceback
+            print("TaskQueue '%s' threw an exception: %s" % task, traceback.format_exc())
+
+
+def _can_retry(task):
+    return hasattr(task, 'nb_remaining_call') and task.nb_remaining_call > 0
+
+RPC_E_SERVERCALL_RETRYLATER = -2147418111
+
+
+def _ask_for_retry(exception):
+    return hasattr(exception, 'hresult') and exception.hresult == RPC_E_SERVERCALL_RETRYLATER

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -166,8 +166,10 @@ class DelayWrite(object):
         self.options = options
         self.value = value
         self.skip = (caller.Rows.Count, caller.Columns.Count)
+        self.nb_remaining_call = 10
 
     def __call__(self, *args, **kwargs):
+        self.nb_remaining_call -= 1
         conversion.write(
             self.value,
             self.range,


### PR DESCRIPTION
Retry COM call in case RPC_E_SERVERCALL_RETRYLATER error is returned (arbitrary set maximum number of retry to 9, total number of trial being 10 then)

For more information refer to https://msdn.microsoft.com/en-us/library/ms228772(v=vs.100).aspx?f=255&MSPPError=-2147217396

I am not fond of the fact that the number of retry is hardcoded here so if you find a way of providing options to xlwings properly it would be nice to introduce a property I guess.
Also please note that 10 might be a number a bit too high, in my case, most of the time 2 or 3 attempts were enough.