### PR TITLE
Display error details in case of exception

### DIFF
--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -344,7 +344,7 @@ def _execute_task(task):
             _execute_task(task)
         else:
             import traceback
-            print("TaskQueue '%s' threw an exception: %s" % task, traceback.format_exc())
+            print("TaskQueue '%s' threw an exception: %s" % (task, traceback.format_exc()))
 
 
 def _can_retry(task):


### PR DESCRIPTION
The syntax was not the right one (tested on Python 2.7 and 3.6):

```
>>> print('%s %s' % ('hello', 'world'))
hello world
>>> print('%s %s' % 'hello', 'world')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not enough arguments for format string
```