### PR TITLE
Avoid RPC_E_SERVERCALL_RETRYLATER failure

### DIFF
--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -25,6 +25,7 @@ import win32com.client
 import win32com.server.util as serverutil
 import win32com.server.dispatcher
 import win32com.server.policy
+import logging
 
 from .udfs import call_udf
 

--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -277,6 +277,7 @@ class XLPython(object):
         exec (stmt, globals, locals)
 
 
+retry_queue = []
 idle_queue = []
 idle_queue_event = win32event.CreateEvent(None, 0, 0, None)
 

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -171,12 +171,14 @@ udf_modules = {}
 
 
 class DelayWrite(object):
+    MAX_NUMBER_RETRY = 10
+    
     def __init__(self, rng, options, value, caller):
         self.range = rng
         self.options = options
         self.value = value
         self.skip = (caller.Rows.Count, caller.Columns.Count)
-        self.nb_remaining_call = 10
+        self.nb_remaining_call = DelayWrite.MAX_NUMBER_RETRY
 
     def __call__(self, *args, **kwargs):
         self.nb_remaining_call -= 1

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -171,17 +171,13 @@ udf_modules = {}
 
 
 class DelayWrite(object):
-    MAX_NUMBER_RETRY = 10
-    
     def __init__(self, rng, options, value, caller):
         self.range = rng
         self.options = options
         self.value = value
         self.skip = (caller.Rows.Count, caller.Columns.Count)
-        self.nb_remaining_call = DelayWrite.MAX_NUMBER_RETRY
 
     def __call__(self, *args, **kwargs):
-        self.nb_remaining_call -= 1
         conversion.write(
             self.value,
             self.range,


### PR DESCRIPTION
When multiple UDFs are depending on the same cell, when this cell is updated all those UDFs will be called by Microsoft Excel.
It seems that Microsoft Excel will ask for a retry until all UDFs have been called.

In order to avoid failure in case this maximum number of retry is reached and all UDFs have still not been properly called, retry should be performed only after last call (the first one that will not be rejected with a retry issue)