### PR TITLE
[docs] Fix a small typo

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,7 +57,7 @@ There are many **convenience features** available, e.g. Range expanding:
 If you want to quickly talk to the active sheet in the active workbook, you don't need instantiate a workbook
 and sheet object, but can simply do:
 
-    >>> import xlwings xw
+    >>> import xlwings as xw
     >>> xw.Range('A1').value = 'Foo'
     >>> xw.Range('A1').value
     'Foo'


### PR DESCRIPTION
Just a small typo in the [quickstart page](http://docs.xlwings.org/en/stable/quickstart.html).
`import xlwings as xw` instead of `import xlwings xw`