### PR TITLE
[docs] Fix a tiny typo in UDFs page

### DIFF
--- a/docs/udfs.rst
+++ b/docs/udfs.rst
@@ -215,7 +215,7 @@ e.g. ``Application``. Note, however, that currently you're acting directly on th
 
     @xw.func
     @xw.arg('xl_app', vba='Application')
-    def get_caller_address(xl_app)
+    def get_caller_address(xl_app):
         return xl_app.Caller.Address
 
 


### PR DESCRIPTION
Just a tiny typo in the [UDFs page](http://docs.xlwings.org/en/stable/udfs.html):
Lack of a colon after the function definition.