### PR TITLE
Read config from (optional) xlwings.conf in workbook's directory

### DIFF
--- a/docs/addin.rst
+++ b/docs/addin.rst
@@ -70,14 +70,20 @@ The format is as follows (keys are uppercase):
 .. note:: Mac Excel 2011 users have to create and edit the config file manually under ``~/.xlwings/xlwings.conf`` as the
     ribbon is not supported.
 
+Workbook Directory Config File
+------------------------------
+
+The global settings of the Ribbon/Config file can be overridden for one or more workbooks by creating a ``xlwings.conf`` file
+in the workbook's directory.
+
 .. _addin_wb_settings:
 
 Workbook Settings
 -----------------
 
-The global settings of the Ribbon/Config file can be overridden for each workbook by adding a sheet with the 
-name ``xlwings.conf``. When you create a new project with ``xlwings quickstart``, it'll already have such a sheet
-but you need to rename it to ``xlwings.conf`` to make it active.
+The global settings of the Ribbon/Config file (and the optional workbook directory config file) can be overridden for each 
+workbook by adding a sheet with the name ``xlwings.conf``. When you create a new project with ``xlwings quickstart``, it'll 
+already have such a sheet but you need to rename it to ``xlwings.conf`` to make it active.
 
 
 .. figure:: images/workbook_config.png

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -1,6 +1,11 @@
 What's New
 ==========
 
+v0.11.5
+-------
+
+* Workbook directory configuration file
+
 v0.11.4 (Jul 23, 2017)
 ----------------------
 

--- a/xlwings/addin/Config.bas
+++ b/xlwings/addin/Config.bas
@@ -15,6 +15,18 @@ Function GetConfigFilePath() As String
     #End If
 End Function
 
+Function GetWorkbookDirectoryConfigFilePath() As String
+    GetWorkbookDirectoryConfigFilePath = GetDirectory(ActiveWorkbook.FullName) & "xlwings.conf"
+End Function
+
+Function GetDirectory(path)
+    #If Mac Then
+    GetDirectory = Left(path, InStrRev(path, "/"))
+    #Else
+    GetDirectory = Left(path, InStrRev(path, "\"))
+    #End If
+End Function
+
 Function GetConfigFromSheet()
     Dim lastCell As Range, cell As Range
     #If Mac Then
@@ -45,6 +57,13 @@ Function GetConfig(configKey As String, Optional default As String = "") As Vari
 
     If SheetExists("xlwings.conf") = True Then
         GetConfig = GetConfigFromSheet.Item(configKey)
+    End If
+    
+    ' An entry in the workbook directory's optional xlwings.conf file overrides the config file/ribbon
+    If GetConfig = "" And FileExists(GetWorkbookDirectoryConfigFilePath()) = True Then
+        If GetConfigFromFile(GetWorkbookDirectoryConfigFilePath(), configKey, configValue) Then
+            GetConfig = configValue
+        End If
     End If
 
     If GetConfig = "" And FileExists(GetConfigFilePath()) = True Then


### PR DESCRIPTION
Current config system is:

- values in xlwings.conf sheet can override ...
- ... values from the user's ~/xlwings.conf file

The code in the PR modifies the config system:

- values in xlwings.conf sheet can override...
- ... values from xlwings.conf file in the workbook's folder can override ...
- ... values from the user's ~/xlwings.conf file

I have a scenario where a xlwings-powered workbook should be deployed to a Citrix environment. This change makes it easier to deploy a package w/ the workbook on the environment. With this change, the automated deployment system can simply create a text file in the workbook's directory.

(contrast without the change: Either make sure all users have ~/xlwings.conf file in their home directories, or use COM automation to modify contents of the workbook's xlwings.conf)