### PR TITLE
Enable cross-platform development of UDFs

### DIFF
--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -44,8 +44,10 @@ else:
     def sub(f):
         return f
 
-    def ret(f):
-        return f
+    def ret(*args, **kwargs):
+        def real_decorator(f):
+            return f
+        return real_decorator
 
     def arg(*args, **kwargs):
         def real_decorator(f):

--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -38,11 +38,15 @@ from .main import apps, books, sheets
 if sys.platform.startswith('win'):
     from .udfs import xlfunc as func, xlsub as sub, xlret as ret, xlarg as arg, get_udf_module, import_udfs
 else:
-    def func(f):
-        return f
+    def func(*args, **kwargs):
+        def real_decorator(f):
+            return f
+        return real_decorator
 
-    def sub(f):
-        return f
+    def sub(*args, **kwargs):
+        def real_decorator(f):
+            return f
+        return real_decorator
 
     def ret(*args, **kwargs):
         def real_decorator(f):

--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -47,8 +47,10 @@ else:
     def ret(f):
         return f
 
-    def arg(f):
-        return f
+    def arg(*args, **kwargs):
+        def real_decorator(f):
+            return f
+        return real_decorator
 
 
 def xlfunc(*args, **kwargs):


### PR DESCRIPTION
Currently, if you have a file that contains UDFs destined for windows, with a decorator like: `@xw.arg('foo', doc='bar')`, this would generate an error on a non-windows platform:

```TypeError: arg() got an unexpected keyword argument 'doc'```