### PR TITLE
WriteValueToRangeStage construction error

### DIFF
--- a/xlwings/conversion/standard.py
+++ b/xlwings/conversion/standard.py
@@ -211,7 +211,7 @@ class RawValueAccessor(Accessor):
     def writer(cls, options):
         return (
             Accessor.writer(options)
-            .prepend_stage(WriteValueToRangeStage(raw=True))
+            .prepend_stage(WriteValueToRangeStage(options, raw=True))
         )
 
 RawValueAccessor.register('raw')


### PR DESCRIPTION
RawValueAccessor is not providing the options argument to the WriteValueToRangeStage constructor.