### PR TITLE
Return UDF result even if 10 return fail

### DIFF
--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -25,6 +25,7 @@ import win32com.client
 import win32com.server.util as serverutil
 import win32com.server.dispatcher
 import win32com.server.policy
+import logging
 
 from .udfs import call_udf
 
@@ -277,6 +278,7 @@ class XLPython(object):
         exec (stmt, globals, locals)
 
 
+retry_queue = []
 idle_queue = []
 idle_queue_event = win32event.CreateEvent(None, 0, 0, None)
 
@@ -338,17 +340,34 @@ def serve(clsid="{506e67c3-55b5-48c3-a035-eed5deea7d6d}"):
 def _execute_task(task):
     try:
         task()
+        logging.debug("Task '{0}' was properly sent to Microsoft Excel.".format(task))
+        for retry_task in retry_queue:
+            # If a retry failed it means that there is still call to be performed
+            # (It should really never occurs as the task triggering those retry was not rejected).
+            if not _retry_task(retry_task):
+                return
+        retry_queue[:] = []
     except Exception as e:
-        if _ask_for_retry(e) and _can_retry(task):
-            print("Retrying TaskQueue '%s'." % task)
-            _execute_task(task)
+        if _ask_for_retry(e):
+            # At least one more call is still to be performed so wait for this new call.
+            logging.debug("Task '{0}' should be retried and was added to the queue.".format(task))
+            retry_queue.append(task)
         else:
-            import traceback
-            print("TaskQueue '%s' threw an exception: %s" % (task, traceback.format_exc()))
+            logging.exception("An error occurred while executing task '{0}'.".format(task))
 
 
-def _can_retry(task):
-    return hasattr(task, 'nb_remaining_call') and task.nb_remaining_call > 0
+def _retry_task(task):
+    try:
+        task()
+        logging.debug("Task '{0}' was properly sent to Microsoft Excel (after retry).".format(task))
+    except Exception as e:
+        if _ask_for_retry(e):
+            logging.warning("Task '{0}' retry failed. Waiting for next successful call to retry.".format(task))
+            return False
+        else:
+            logging.exception("An error occurred while executing task '{0}'.".format(task))
+    return True
+
 
 RPC_E_SERVERCALL_RETRYLATER = -2147418111
 

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -176,10 +176,8 @@ class DelayWrite(object):
         self.options = options
         self.value = value
         self.skip = (caller.Rows.Count, caller.Columns.Count)
-        self.nb_remaining_call = 10
 
     def __call__(self, *args, **kwargs):
-        self.nb_remaining_call -= 1
         conversion.write(
             self.value,
             self.range,


### PR DESCRIPTION
When result cannot be sent because Excel is busy, wait for next successful call to return result