### PR TITLE
make retrying tasks more robust

### DIFF
--- a/xlwings/server.py
+++ b/xlwings/server.py
@@ -8,6 +8,7 @@ except:
     raise Exception("Cannot import PyWin32. Are you sure it's installed?")
 import sys
 import os
+import collections
 # Hack to find pythoncom.dll - needed for some distribution/setups
 # E.g. if python is started with the full path outside of the python path, then it almost certainly fails
 cwd = os.getcwd()
@@ -277,7 +278,7 @@ class XLPython(object):
         exec (stmt, globals, locals)
 
 
-idle_queue = []
+idle_queue = collections.deque()
 idle_queue_event = win32event.CreateEvent(None, 0, 0, None)
 
 
@@ -314,43 +315,46 @@ def serve(clsid="{506e67c3-55b5-48c3-a035-eed5deea7d6d}"):
 
     print('xlwings server running, clsid=%s' % clsid)
 
+    waitables = [idle_queue_event]
     while True:
+        timeout = TIMEOUT if idle_queue else win32event.INFINITE
         rc = win32event.MsgWaitForMultipleObjects(
-            [idle_queue_event],
+            waitables,
             0,
-            win32event.INFINITE,
+            timeout,
             win32event.QS_ALLEVENTS
         )
+        if rc == win32event.WAIT_OBJECT_0 or rc == win32event.WAIT_TIMEOUT:
+            while idle_queue:
+                task = idle_queue.popleft()
+                if not _execute_task(task):
+                    break
 
-        while True:
-            pythoncom.PumpWaitingMessages()
-
-            if not idle_queue:
-                break
-
-            task = idle_queue.pop(0)
-            _execute_task(task)
+        elif rc == win32event.WAIT_OBJECT_0 + len(waitables):
+            if pythoncom.PumpWaitingMessages():
+                break  # wm_quit
 
     pythoncom.CoRevokeClassObject(revokeId)
     pythoncom.CoUninitialize()
 
 
 def _execute_task(task):
+    """ Execute task. Returns False if task must be retried later. """
     try:
         task()
     except Exception as e:
-        if _ask_for_retry(e) and _can_retry(task):
+        if _ask_for_retry(e):
             print("Retrying TaskQueue '%s'." % task)
-            _execute_task(task)
+            idle_queue.appendleft(task)
+            return False
         else:
             import traceback
             print("TaskQueue '%s' threw an exception: %s" % (task, traceback.format_exc()))
+    return True
 
-
-def _can_retry(task):
-    return hasattr(task, 'nb_remaining_call') and task.nb_remaining_call > 0
 
 RPC_E_SERVERCALL_RETRYLATER = -2147418111
+TIMEOUT = 100  # ms
 
 
 def _ask_for_retry(exception):

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -176,10 +176,8 @@ class DelayWrite(object):
         self.options = options
         self.value = value
         self.skip = (caller.Rows.Count, caller.Columns.Count)
-        self.nb_remaining_call = 10
 
     def __call__(self, *args, **kwargs):
-        self.nb_remaining_call -= 1
         conversion.write(
             self.value,
             self.range,


### PR DESCRIPTION
As mentioned in issue  #880   xlwings drops a delayed write (used for implementing dynamic UDFs) after 10 retries (a retry happens when call to Excel returns RPC_E_SERVERCALL_RETRYLATER). 
This PR removes limit on the number of retries while at the same not clogging the system. It is implemented by retrying periodically (at least every 100 ms) or earlier (when another task arrives).
The comments of issues #880 discuss the difference with PR #872 .