### PR TITLE
Preserve docstring of UDFs in non windows environments

### DIFF
--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from functools import wraps
 import sys
 
 
@@ -38,7 +39,8 @@ from .main import apps, books, sheets
 if sys.platform.startswith('win'):
     from .udfs import xlfunc as func, xlsub as sub, xlret as ret, xlarg as arg, get_udf_module, import_udfs
 else:
-    def func(*args, **kwargs):
+    def func(f=None, *args, **kwargs):
+        @wraps(f)
         def real_decorator(f):
             return f
         return real_decorator


### PR DESCRIPTION
When working in windows environment, the `@xw.func` decorator for UDFs [preserves the docstring](https://github.com/ZoomerAnalytics/xlwings/blob/master/xlwings/udfs.py#L119).

In non windows environment, since UDFs are not supported, the decorator is replaced by a [dummy function](https://github.com/ZoomerAnalytics/xlwings/blob/master/xlwings/__init__.py#L38).

However, the docstring may still be useful for generating automated documentation, for instance with [Sphinx](http://www.sphinx-doc.org/en/master/)'s `.. automodule::` directive.