### PR TITLE
Error handling when range has formulas which return #NA. 

### DIFF
--- a/xlwings/conversion/standard.py
+++ b/xlwings/conversion/standard.py
@@ -104,7 +104,9 @@ class AdjustDimensionsStage(object):
         # the assumption is that value is 2-dimensional at this stage
 
         if self.ndim is None:
-            if len(c.value) == 1:
+            if len(c.value) == 0:
+                c.value = ""
+            elif len(c.value) == 1:
                 c.value = c.value[0][0] if len(c.value[0]) == 1 else c.value[0]
             elif len(c.value[0]) == 1:
                 c.value = [x[0] for x in c.value]
@@ -112,7 +114,9 @@ class AdjustDimensionsStage(object):
                 c.value = c.value
 
         elif self.ndim == 1:
-            if len(c.value) == 1:
+            if len(c.value) == 0:
+                c.value = ""
+            elif len(c.value) == 1:
                 c.value = c.value[0]
             elif len(c.value[0]) == 1:
                 c.value = [x[0] for x in c.value]


### PR DESCRIPTION
While accessing ws.range("A2:A100") if formulas can't be evaluated - all of them returns NA. we get an exception as we try and access -> c.value[0] in line 109 which results in this error