### PR TITLE
Allow installation of xlwings on Linux even though it can't be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,8 @@ elif sys.platform.startswith('darwin'):
     install_requires = ['psutil >= 2.0.0', 'appscript >= 1.0.1']
     data_files = [(os.path.expanduser("~") + '/Library/Application Scripts/com.microsoft.Excel', ['xlwings/xlwings.applescript'])]
 else:
-    on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-    if on_rtd:
-        data_files = []
-        install_requires = []
-    else:
-        raise OSError("currently only Windows and OSX are supported.")
+    data_files = []
+    install_requires = []
 
 # This shouldn't be necessary anymore as we dropped official support for < 2.7 and < 3.3
 if (sys.version_info[0] == 2 and sys.version_info[:2] < (2, 7)) or (sys.version_info[0] == 3 and sys.version_info[:2] < (3, 2)):


### PR DESCRIPTION
Hi :),

This library has been massively helpful for bridging the gap between Python code and Excel users. I massively appreciate it, thank you.

I am building a library called PyMedPhys (https://github.com/pymedphys/pymedphys). I develop this library on Windows and Linux, and run CI on Windows, Linux and Mac. Part of the testing framework is to run pylint within pytest. I understand that xlwings is not supported on Linux, however, when it is installed on Linux it does still enable rudimentary sanity checking via pylint.

I am very keen to be able to have xlwings installed on Linux even just so that it can be used by pylint.

Hence this pull request.

Cheers,
Simon